### PR TITLE
장부 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,97 +1,100 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.3'
-	id 'io.spring.dependency-management' version '1.1.6'
-	id 'org.asciidoctor.jvm.convert' version "3.3.2"
+    id 'java'
+    id 'org.springframework.boot' version '3.3.3'
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.asciidoctor.jvm.convert' version "3.3.2"
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	asciidoctorExtensions
+    asciidoctorExtensions
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
-
-
-	//SPRING_REST_DOCS
-	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-
-	//JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
-	//VALIDATION
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-	//MYSQL
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	testImplementation 'com.h2database:h2'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
 
-	//JSONObject
-	implementation 'org.json:json:20230227'
+    //SPRING_REST_DOCS
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //VALIDATION
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //MYSQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'com.h2database:h2'
+
+
+    //JSONObject
+    implementation 'org.json:json:20230227'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 ext {
-	snippetsDir = file('./build/generated-snippets')
+    snippetsDir = file('./build/generated-snippets')
 }
 
 test {
-	useJUnitPlatform()
-	outputs.dir snippetsDir
+    useJUnitPlatform()
+    outputs.dir snippetsDir
 }
 
 asciidoctor.doFirst {
-	delete file("src/main/resources/static/docs")
+    delete file("src/main/resources/static/docs")
 }
 
 asciidoctor {
-	inputs.dir snippetsDir
-	dependsOn test
-	configurations 'asciidoctorExtensions'
+    inputs.dir snippetsDir
+    dependsOn test
+    configurations 'asciidoctorExtensions'
 }
 
 bootJar {
-	dependsOn asciidoctor
-	copy {
-		from("${asciidoctor.outputDir}")
-		into 'src/main/resources/static/docs'
-	}
+    dependsOn asciidoctor
+    copy {
+        from("${asciidoctor.outputDir}")
+        into 'src/main/resources/static/docs'
+    }
 }
 
 task copyDocument(type: Copy) {
-	dependsOn asciidoctor
-	from file("$build/docs/asciidoc")
-	into file("src/main/resources/static/docs")
+    dependsOn asciidoctor
+    from file("$build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
 }
 
 build {
-	dependsOn copyDocument
+    dependsOn copyDocument
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/jangboo/accountBook/application/AccountBookService.java
+++ b/src/main/java/com/example/jangboo/accountBook/application/AccountBookService.java
@@ -1,0 +1,31 @@
+package com.example.jangboo.accountBook.application;
+
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookListRequestDto;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.in.CreateAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookDetailResponseDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookResponseDto;
+import com.example.jangboo.accountBook.dto.out.ApproveAccountBookListResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AccountBookService {
+
+    void createAccountBook(CreateAccountBookRequestDto requestDto);
+
+    Page<AccountBookResponseDto> getAccountBookList(AccountBookStatus status,
+                                                    LocalDateTime fromDate,
+                                                    LocalDateTime toDate,
+                                                    Pageable pageable);
+
+    AccountBookDetailResponseDto getAccountBook(Long accountBookId);
+
+    List<ApproveAccountBookListResponseDto> getApproveAccountBookList(ApproveAccountBookListRequestDto requestDto);
+
+    void approveAccountBook(ApproveAccountBookRequestDto requestDto);
+
+}

--- a/src/main/java/com/example/jangboo/accountBook/application/AccountBookServiceImpl.java
+++ b/src/main/java/com/example/jangboo/accountBook/application/AccountBookServiceImpl.java
@@ -1,0 +1,179 @@
+package com.example.jangboo.accountBook.application;
+
+import com.example.jangboo.accountBook.domain.AccountBook;
+import com.example.jangboo.accountBook.domain.AccountBookSign;
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookListRequestDto;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.in.CreateAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookDetailResponseDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookResponseDto;
+import com.example.jangboo.accountBook.dto.out.ApproveAccountBookListResponseDto;
+import com.example.jangboo.accountBook.infrastructure.AccountBookRepository;
+import com.example.jangboo.accountBook.infrastructure.AccountBookSignRepository;
+import com.example.jangboo.role.domain.Role;
+import com.example.jangboo.role.domain.RoleRepository;
+import com.example.jangboo.role.domain.RoleType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountBookServiceImpl implements AccountBookService {
+
+    private final AccountBookRepository accountBookRepository;
+    private final AccountBookSignRepository accountBookSignRepository;
+    private final RoleRepository roleRepository;
+
+    //장부 등록하기
+    @Override
+    @Transactional
+    public void createAccountBook(CreateAccountBookRequestDto requestDto) {
+
+        // Role 엔티티에서 userId에 해당하는 Role을 가져옴
+        Role userRole = roleRepository.findByStudentId(requestDto.getUserId()).stream().findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("역할을 찾을 수 없습니다."));
+
+        // RoleType이 AUDITOR가 아닐 경우 예외 처리
+        if (userRole.getRole() != RoleType.AUDITOR) {
+            throw new IllegalArgumentException("장부 등록은 감사(AUDITOR)만 가능합니다.");
+        }
+
+        AccountBook accountBook = AccountBook.builder()
+                .receiptId(requestDto.getReceiptId())
+                .deptId(requestDto.getDeptId())
+                .transactionId(requestDto.getTransactionId())
+                .docNum(requestDto.getDocNum())
+                .createdAt(requestDto.getCreatedAt())
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .amount(requestDto.getAmount())
+                .status(AccountBookStatus.UNAUDITED)
+                .build();
+
+        AccountBookSign accountBookSign = AccountBookSign.builder()
+                .presidentApproval(false)
+                .vicePresidentApproval(false)
+                .auditApproval(false)
+                .build();
+
+        accountBook.setAccountBookSign(accountBookSign);
+
+        accountBookRepository.save(accountBook);
+        accountBookSignRepository.save(accountBookSign);
+    }
+
+    //장부 리스트 조회
+    @Override
+    @Transactional(readOnly = true)
+    public Page<AccountBookResponseDto> getAccountBookList(AccountBookStatus status,
+                                                           LocalDateTime fromDate,
+                                                           LocalDateTime toDate,
+                                                           Pageable pageable) {
+
+        Page<AccountBook> accountBooks = accountBookRepository.findByStatusAndDateRange(status,
+                fromDate,
+                toDate,
+                pageable);
+
+        return accountBooks.map(AccountBookResponseDto::fromEntity);
+    }
+
+    //장부 상세 조회
+    @Override
+    @Transactional(readOnly = true)
+    public AccountBookDetailResponseDto getAccountBook(Long accountBookId) {
+
+        AccountBook accountBook = accountBookRepository.findById(accountBookId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 장부가 존재하지 않습니다."));
+
+        return AccountBookDetailResponseDto.fromEntity(accountBook);
+    }
+
+    //승인 해야할 장부 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<ApproveAccountBookListResponseDto> getApproveAccountBookList(ApproveAccountBookListRequestDto requestDto) {
+
+        List<Role> roles = roleRepository.findByStudentId(requestDto.getUserId());
+
+        RoleType roleType = roles.stream()
+                .map(Role::getRole)
+                .findFirst()  // RoleType은 여러 개? 최상위 하나만?
+                .orElseThrow(() -> new IllegalArgumentException("역할이 존재하지 않음"));
+
+        List<AccountBook> accountBooks;
+
+        if (roleType == RoleType.VICE_PRESIDENT) {
+            //장부 상태가 미감사인 것 중 부회장 승인이 안 된 것
+            accountBooks = accountBookRepository.findByStatusAndAccountBookSign_VicePresidentApprovalFalse(AccountBookStatus.UNAUDITED);
+        } else if (roleType == RoleType.PRESIDENT) {
+            //장부 상태가 미감사인 것 중 부회장 승인은 됐고 회장 승인은 안 된 것
+            accountBooks = accountBookRepository.findByStatusAndAccountBookSign_VicePresidentApprovalTrueAndAccountBookSign_PresidentApprovalFalse(AccountBookStatus.UNAUDITED);
+        } else if (roleType == RoleType.AUDITOR) {
+            //장부 상태가 미감사인 것 중 부회장, 회장 승인은 됐고 감사 승인은 안 된 것
+            accountBooks = accountBookRepository.findByStatusAndAccountBookSign_PresidentApprovalTrueAndAccountBookSign_VicePresidentApprovalTrueAndAccountBookSign_AuditApprovalFalse(AccountBookStatus.UNAUDITED);
+        } else {
+            throw new IllegalArgumentException("승인 권한이 없는 역할입니다.");
+        }
+
+        return accountBooks.stream()
+                .map(ApproveAccountBookListResponseDto::fromEntity)
+                .toList();
+    }
+
+    //장부 승인 및 반려하기
+    @Override
+    @Transactional
+    public void approveAccountBook(ApproveAccountBookRequestDto requestDto) {
+
+        // AccountBook 찾기
+        AccountBook accountBook = accountBookRepository.findById(requestDto.getAccountBookId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 장부가 존재하지 않습니다."));
+
+        // AccountBookSign 찾기
+        AccountBookSign accountBookSign = accountBook.getAccountBookSign();
+
+        // 역할 찾기
+        RoleType roleType = roleRepository.findByStudentId(requestDto.getUserId())
+                .stream()
+                .map(Role::getRole)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("역할이 존재하지 않음"));
+
+        // 승인 여부 업데이트
+        // 상위 직급의 승인 여부는 이미 승인 해야할 장부 조회 API에서 걸러졌기 때문에 예외 처리를 안 함
+        if (roleType == RoleType.VICE_PRESIDENT) {
+            accountBookSign.setVicePresidentApproval(requestDto.isApproval());
+        } else if (roleType == RoleType.PRESIDENT) {
+            accountBookSign.setPresidentApproval(requestDto.isApproval());
+        } else if (roleType == RoleType.AUDITOR) {
+            accountBookSign.setAuditApproval(requestDto.isApproval());
+        } else {
+            throw new IllegalArgumentException("승인 권한이 없는 역할입니다.");
+        }
+
+        // 승인 여부가 하나라도 false일 경우 처리
+        if (!requestDto.isApproval()) {
+            // AccountBook 상태를 UNAPPROVED로 변경
+            accountBook.setStatus(AccountBookStatus.UNAPPROVED);
+
+            // AccountBookSign의 모든 승인 값들을 false로 되돌림
+            accountBookSign.setPresidentApproval(false);
+            accountBookSign.setVicePresidentApproval(false);
+            accountBookSign.setAuditApproval(false);
+        }
+
+        // 변경사항 저장
+        accountBookSignRepository.save(accountBookSign);
+        accountBookRepository.save(accountBook);
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/domain/AccountBook.java
+++ b/src/main/java/com/example/jangboo/accountBook/domain/AccountBook.java
@@ -1,0 +1,83 @@
+package com.example.jangboo.accountBook.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@ToString
+public class AccountBook {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_book_id")
+    private Long id;
+
+    @Comment("장부 서명 id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_book_sign_id")
+    private AccountBookSign accountBookSign;
+
+    @Comment("영수증 id")
+    @Column(nullable = false, name = "receipt_id")
+    private Long receiptId;
+
+    @Comment("학과 id")
+    @Column(nullable = false, name = "dept_id")
+    private Long deptId;
+
+    @Comment("거래내역 id")
+    @Column(nullable = false, name = "transaction_id")
+    private Long transactionId;
+
+    @Comment("문서 번호")
+    @Column(nullable = false, name = "doc_num")
+    private Long docNum;
+
+    @Comment("거래일시")
+    @Column(nullable = false, name = "transaction_date")
+    private LocalDateTime createdAt;
+
+    @Comment("제목")
+    @Column(nullable = false, length = 100, name = "title")
+    private String title;
+
+    @Comment("내용")
+    @Column(nullable = false, length = 100, name = "content")
+    private String content;
+
+    @Comment("총 비용")
+    @Column(nullable = false, name = "amount")
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "status")
+    private AccountBookStatus status;
+
+    @Builder
+    public AccountBook(Long receiptId, Long deptId, Long transactionId, Long docNum, LocalDateTime createdAt, String title, String content, Long amount, AccountBookStatus status) {
+        this.receiptId = receiptId;
+        this.deptId = deptId;
+        this.transactionId = transactionId;
+        this.docNum = docNum;
+        this.createdAt = createdAt;
+        this.title = title;
+        this.content = content;
+        this.amount = amount;
+        this.status = status;
+    }
+
+    public void setAccountBookSign(AccountBookSign accountBookSign) {
+        this.accountBookSign = accountBookSign;
+    }
+
+    public void setStatus(AccountBookStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/domain/AccountBookSign.java
+++ b/src/main/java/com/example/jangboo/accountBook/domain/AccountBookSign.java
@@ -1,0 +1,51 @@
+package com.example.jangboo.accountBook.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@ToString
+public class AccountBookSign {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_book_sign_id")
+    private Long id;
+
+    @Comment("회장 승인 여부")
+    @Column(nullable = false, name = "president_approval")
+    private Boolean presidentApproval;
+
+    @Comment("부회장 승인 여부")
+    @Column(nullable = false, name = "vice_president_approval")
+    private Boolean vicePresidentApproval;
+
+    @Comment("감사 승인 여부")
+    @Column(nullable = false, name = "audit_approval")
+    private Boolean auditApproval;
+
+    @Builder
+    public AccountBookSign(Boolean presidentApproval, Boolean vicePresidentApproval, Boolean auditApproval) {
+        this.presidentApproval = presidentApproval != null ? presidentApproval : false;
+        this.vicePresidentApproval = vicePresidentApproval != null ? vicePresidentApproval : false;
+        this.auditApproval = auditApproval != null ? auditApproval : false;
+    }
+
+    public void setPresidentApproval(Boolean approval) {
+        this.presidentApproval = approval;
+    }
+
+    public void setVicePresidentApproval(Boolean approval) {
+        this.vicePresidentApproval = approval;
+    }
+
+    public void setAuditApproval(Boolean approval) {
+        this.auditApproval = approval;
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/domain/AccountBookStatus.java
+++ b/src/main/java/com/example/jangboo/accountBook/domain/AccountBookStatus.java
@@ -1,0 +1,6 @@
+package com.example.jangboo.accountBook.domain;
+
+public enum AccountBookStatus {
+    // 미승인(거절 당함), 미감사(아직 검사하지 않음), 공개장부(모든 과정을 거침)
+    UNAPPROVED, UNAUDITED, PUBLIC
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/in/ApproveAccountBookListRequestDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/in/ApproveAccountBookListRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.jangboo.accountBook.dto.in;
+
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApproveAccountBookListRequestDto {
+
+    private AccountBookStatus status;
+    private Long userId;
+    private Long deptId;
+
+    public ApproveAccountBookListRequestDto(AccountBookStatus status, Long userId, Long deptId) {
+        this.status = status;
+        this.userId = userId;
+        this.deptId = deptId;
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/in/ApproveAccountBookRequestDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/in/ApproveAccountBookRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.jangboo.accountBook.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApproveAccountBookRequestDto {
+    private Long accountBookId;
+    private boolean approval;
+    private Long userId;
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/in/CreateAccountBookRequestDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/in/CreateAccountBookRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.jangboo.accountBook.dto.in;
+
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+public class CreateAccountBookRequestDto {
+    private Long userId;
+    private Long receiptId;
+    private Long transactionId;
+    private Long deptId;
+    private Long docNum;
+    private LocalDateTime createdAt;
+    private String title;
+    private String content;
+    private Long amount;
+    private AccountBookStatus status;
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/out/AccountBookDetailResponseDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/out/AccountBookDetailResponseDto.java
@@ -1,0 +1,56 @@
+package com.example.jangboo.accountBook.dto.out;
+
+import com.example.jangboo.accountBook.domain.AccountBook;
+import com.example.jangboo.accountBook.vo.out.AccountBookDetailResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class AccountBookDetailResponseDto {
+    private Long id;
+    private Long accountBookSignId;
+    private Long receiptId;
+    private Long deptId;
+    private Long transactionId;
+    private Long docNum;
+    private LocalDateTime createdAt;
+    private String title;
+    private String content;
+    private Long amount;
+    private String status;
+
+    public static AccountBookDetailResponseDto fromEntity(AccountBook accountBook) {
+        return AccountBookDetailResponseDto.builder()
+                .id(accountBook.getId())
+                .accountBookSignId(accountBook.getAccountBookSign().getId())
+                .receiptId(accountBook.getReceiptId())
+                .deptId(accountBook.getDeptId())
+                .transactionId(accountBook.getTransactionId())
+                .docNum(accountBook.getDocNum())
+                .createdAt(accountBook.getCreatedAt())
+                .title(accountBook.getTitle())
+                .content(accountBook.getContent())
+                .amount(accountBook.getAmount())
+                .status(accountBook.getStatus().name())
+                .build();
+    }
+
+    public AccountBookDetailResponseVo toVo() {
+        return AccountBookDetailResponseVo.builder()
+                .id(id)
+                .accountBookSignId(accountBookSignId)
+                .receiptId(receiptId)
+                .deptId(deptId)
+                .transactionId(transactionId)
+                .docNum(docNum)
+                .createdAt(createdAt)
+                .title(title)
+                .content(content)
+                .amount(amount)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/out/AccountBookResponseDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/out/AccountBookResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.jangboo.accountBook.dto.out;
+
+import com.example.jangboo.accountBook.domain.AccountBook;
+import com.example.jangboo.accountBook.vo.out.AccountBookResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AccountBookResponseDto {
+    private Long id;
+    private Long docNum;
+    private String title;
+    private Long amount;
+
+    public static AccountBookResponseDto fromEntity(AccountBook accountBook) {
+        return AccountBookResponseDto.builder()
+                .id(accountBook.getId())
+                .docNum(accountBook.getDocNum())
+                .title(accountBook.getTitle())
+                .amount(accountBook.getAmount())
+                .build();
+    }
+
+    public AccountBookResponseVo toVo() {
+        return AccountBookResponseVo.builder()
+                .id(id)
+                .docNum(docNum)
+                .title(title)
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/dto/out/ApproveAccountBookListResponseDto.java
+++ b/src/main/java/com/example/jangboo/accountBook/dto/out/ApproveAccountBookListResponseDto.java
@@ -1,0 +1,41 @@
+package com.example.jangboo.accountBook.dto.out;
+
+import com.example.jangboo.accountBook.domain.AccountBook;
+import com.example.jangboo.accountBook.domain.AccountBookSign;
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import com.example.jangboo.accountBook.vo.out.ApproveAccountBookListResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApproveAccountBookListResponseDto {
+    private Long id;
+    private AccountBookSign accountBookSign;
+    private Long docNum;
+    private String title;
+    private Long amount;
+    private AccountBookStatus status;
+
+    public static ApproveAccountBookListResponseDto fromEntity(AccountBook accountBook) {
+        return ApproveAccountBookListResponseDto.builder()
+                .id(accountBook.getId())
+                .accountBookSign(accountBook.getAccountBookSign())
+                .docNum(accountBook.getDocNum())
+                .title(accountBook.getTitle())
+                .amount(accountBook.getAmount())
+                .status(accountBook.getStatus())
+                .build();
+    }
+
+    public ApproveAccountBookListResponseVo toVo() {
+        return ApproveAccountBookListResponseVo.builder()
+                .id(id)
+                .accountBookSign(accountBookSign)
+                .docNum(docNum)
+                .title(title)
+                .amount(amount)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/infrastructure/AccountBookRepository.java
+++ b/src/main/java/com/example/jangboo/accountBook/infrastructure/AccountBookRepository.java
@@ -1,0 +1,29 @@
+package com.example.jangboo.accountBook.infrastructure;
+
+
+import com.example.jangboo.accountBook.domain.AccountBook;
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AccountBookRepository extends JpaRepository<AccountBook, Long> {
+
+    @Query("SELECT a FROM AccountBook a WHERE a.status = :status AND a.createdAt BETWEEN :fromDate AND :toDate")
+    Page<AccountBook> findByStatusAndDateRange(@Param("status") AccountBookStatus status,
+                                               @Param("fromDate") LocalDateTime fromDate,
+                                               @Param("toDate") LocalDateTime toDate,
+                                               Pageable pageable);
+
+    List<AccountBook> findByStatusAndAccountBookSign_VicePresidentApprovalFalse(AccountBookStatus status);
+
+    List<AccountBook> findByStatusAndAccountBookSign_VicePresidentApprovalTrueAndAccountBookSign_PresidentApprovalFalse(AccountBookStatus status);
+
+    List<AccountBook> findByStatusAndAccountBookSign_PresidentApprovalTrueAndAccountBookSign_VicePresidentApprovalTrueAndAccountBookSign_AuditApprovalFalse(AccountBookStatus status);
+
+}

--- a/src/main/java/com/example/jangboo/accountBook/infrastructure/AccountBookSignRepository.java
+++ b/src/main/java/com/example/jangboo/accountBook/infrastructure/AccountBookSignRepository.java
@@ -1,0 +1,8 @@
+package com.example.jangboo.accountBook.infrastructure;
+
+import com.example.jangboo.accountBook.domain.AccountBookSign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountBookSignRepository extends JpaRepository<AccountBookSign, Long> {
+
+}

--- a/src/main/java/com/example/jangboo/accountBook/presentation/AccountBookController.java
+++ b/src/main/java/com/example/jangboo/accountBook/presentation/AccountBookController.java
@@ -1,0 +1,126 @@
+package com.example.jangboo.accountBook.presentation;
+
+import com.example.jangboo.accountBook.application.AccountBookService;
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookListRequestDto;
+import com.example.jangboo.accountBook.dto.in.ApproveAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.in.CreateAccountBookRequestDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookDetailResponseDto;
+import com.example.jangboo.accountBook.dto.out.AccountBookResponseDto;
+import com.example.jangboo.accountBook.dto.out.ApproveAccountBookListResponseDto;
+import com.example.jangboo.accountBook.vo.in.CreateAccountBookRequestVo;
+import com.example.jangboo.accountBook.vo.out.AccountBookDetailResponseVo;
+import com.example.jangboo.accountBook.vo.out.AccountBookResponseVo;
+import com.example.jangboo.accountBook.vo.out.ApproveAccountBookListResponseVo;
+import com.example.jangboo.auth.controller.dto.Info.CurrentUserInfo;
+import com.example.jangboo.global.dto.ResultDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/account-books")
+public class AccountBookController {
+
+    private final AccountBookService accountBookService;
+
+    //장부 등록하기
+    @Operation(summary = "장부 등록하기", tags = {"장부"})
+    @PostMapping
+    public ResponseEntity<ResultDto<String>> createAccountBook(@RequestBody CreateAccountBookRequestVo createAccountBookRequestVo,
+                                                               @AuthenticationPrincipal CurrentUserInfo info) {
+        CreateAccountBookRequestDto createAccountBookRequestDto = CreateAccountBookRequestDto.builder()
+                .userId(info.userId())
+                .receiptId(createAccountBookRequestVo.getReceiptId())
+                .deptId(info.deptId())
+                .transactionId(createAccountBookRequestVo.getTransactionId())
+                .docNum(createAccountBookRequestVo.getDocNum())
+                .createdAt(createAccountBookRequestVo.getCreatedAt())
+                .title(createAccountBookRequestVo.getTitle())
+                .content(createAccountBookRequestVo.getContent())
+                .amount(createAccountBookRequestVo.getAmount())
+                .build();
+
+        accountBookService.createAccountBook(createAccountBookRequestDto);
+
+        return ResponseEntity.ok(ResultDto.of(200, "장부 등록 성공", null));
+    }
+
+    //장부 리스트 조회
+    @Operation(summary = "장부 리스트 조회", tags = {"장부"})
+    @GetMapping
+    public ResponseEntity<ResultDto<Page<AccountBookResponseVo>>> getAccountBookList(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) LocalDateTime fromDate,
+            @RequestParam(required = false) LocalDateTime toDate,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int pageSize) {
+
+        PageRequest pageable = PageRequest.of(page - 1, pageSize);
+
+        Page<AccountBookResponseDto> accountBooks = accountBookService.getAccountBookList(AccountBookStatus.valueOf(status), fromDate, toDate, pageable);
+
+        Page<AccountBookResponseVo> accountBookResponseVos = accountBooks.map(AccountBookResponseDto::toVo);
+
+        return ResponseEntity.ok(ResultDto.of(200, "장부 조회 성공", accountBookResponseVos));
+    }
+
+
+    // 장부 상세 조회
+    @Operation(summary = "장부 상세 조회", tags = {"장부"})
+    @GetMapping("/{accountBookId}")
+    public ResponseEntity<ResultDto<AccountBookDetailResponseVo>> getAccountBook(
+            @PathVariable Long accountBookId) {
+
+        AccountBookDetailResponseDto accountBook = accountBookService.getAccountBook(accountBookId);
+
+        return ResponseEntity.ok(ResultDto.of(200, "장부 조회 성공", accountBook.toVo()));
+    }
+
+    // 승인 해야할 장부 조회
+    @Operation(summary = "승인 해야할 장부 조회", tags = {"장부"})
+    @GetMapping("/approve")
+    public ResponseEntity<ResultDto<List<ApproveAccountBookListResponseVo>>> getApproveAccountBookList(@AuthenticationPrincipal CurrentUserInfo info) {
+
+        ApproveAccountBookListRequestDto approveAccountBookListRequestDto = ApproveAccountBookListRequestDto.builder()
+                .userId(info.userId())
+                .deptId(info.deptId())
+                .build();
+
+        List<ApproveAccountBookListResponseDto> accountBooks = accountBookService.getApproveAccountBookList(approveAccountBookListRequestDto);
+
+        List<ApproveAccountBookListResponseVo> accountBookResponseVos = accountBooks.stream()
+                .map(ApproveAccountBookListResponseDto::toVo)
+                .toList();
+
+        return ResponseEntity.ok(ResultDto.of(200, "승인 해야할 장부 조회 성공", accountBookResponseVos));
+    }
+
+    // 장부 승인 및 반려하기
+    @Operation(summary = "장부 승인 및 반려하기", tags = {"장부"})
+    @PostMapping("/approve/{accountBookId}")
+    public ResponseEntity<ResultDto<String>> approveAccountBook(@PathVariable Long accountBookId,
+                                                                @RequestParam boolean approval,
+                                                                @AuthenticationPrincipal CurrentUserInfo info) {
+
+        ApproveAccountBookRequestDto approveAccountBookRequestDto = ApproveAccountBookRequestDto.builder()
+                .accountBookId(accountBookId)
+                .approval(approval)
+                .userId(info.userId())
+                .build();
+
+        accountBookService.approveAccountBook(approveAccountBookRequestDto);
+
+        return ResponseEntity.ok(ResultDto.of(200, "장부 승인/반려 성공", null));
+    }
+}

--- a/src/main/java/com/example/jangboo/accountBook/vo/in/CreateAccountBookRequestVo.java
+++ b/src/main/java/com/example/jangboo/accountBook/vo/in/CreateAccountBookRequestVo.java
@@ -1,0 +1,18 @@
+package com.example.jangboo.accountBook.vo.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class CreateAccountBookRequestVo {
+    private Long receiptId;
+    private Long transactionId;
+    private Long docNum;
+    private LocalDateTime createdAt;
+    private String title;
+    private String content;
+    private Long amount;
+}

--- a/src/main/java/com/example/jangboo/accountBook/vo/out/AccountBookDetailResponseVo.java
+++ b/src/main/java/com/example/jangboo/accountBook/vo/out/AccountBookDetailResponseVo.java
@@ -1,0 +1,23 @@
+package com.example.jangboo.accountBook.vo.out;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class AccountBookDetailResponseVo {
+    private Long id;
+    private Long accountBookSignId;
+    private Long receiptId;
+    private Long deptId;
+    private Long transactionId;
+    private Long docNum;
+    private LocalDateTime createdAt;
+    private String title;
+    private String content;
+    private Long amount;
+    private String status;
+
+}

--- a/src/main/java/com/example/jangboo/accountBook/vo/out/AccountBookResponseVo.java
+++ b/src/main/java/com/example/jangboo/accountBook/vo/out/AccountBookResponseVo.java
@@ -1,0 +1,13 @@
+package com.example.jangboo.accountBook.vo.out;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AccountBookResponseVo {
+    private Long id;
+    private Long docNum;
+    private String title;
+    private Long amount;
+}

--- a/src/main/java/com/example/jangboo/accountBook/vo/out/ApproveAccountBookListResponseVo.java
+++ b/src/main/java/com/example/jangboo/accountBook/vo/out/ApproveAccountBookListResponseVo.java
@@ -1,0 +1,17 @@
+package com.example.jangboo.accountBook.vo.out;
+
+import com.example.jangboo.accountBook.domain.AccountBookSign;
+import com.example.jangboo.accountBook.domain.AccountBookStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApproveAccountBookListResponseVo {
+    private Long id;
+    private AccountBookSign accountBookSign;
+    private Long docNum;
+    private String title;
+    private Long amount;
+    private AccountBookStatus status;
+}

--- a/src/main/java/com/example/jangboo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/jangboo/global/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.example.jangboo.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenApi() {
+
+        Info info = new Info()
+                .title("SiVillage API")
+                .version("0.01")
+                .description("SiVillage API")
+                .termsOfService("http://swagger.io/terms/");
+
+        // Security Secheme명
+        String jwtSchemeName = "jwtAuth";
+
+        // API
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // SecuritySchemes 설정
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER) //
+                        .name("Authorization"));
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
## 설명
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->
- #10 
### 장부 리스트 조회 API
- status에 따른 장부 리스트 조회 가능
- 반려된 장부일 경우 총무는 UNAPPROVED status를 넣어서 확인 가능
###  장부 상세 조회 API
### 장부 등록하기 API
- 총무만 장부를 등록할 수 있게
### 승인 해야 할 장부 조회 API
- 부회장, 회장, 감사 순서로 승인 해야 할 장부 조회 가능
### 장부 승인 및 반려하기 API
- 셋 중 한명이라도 반려 시 장부 status 자체가 UNAPPROVED로 변경
- 이에따라 SignStatus도 모두 false로 변경
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 참고사항
