### PR TITLE
계좌도메인 및 거래내역 도메인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
 	//AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 ext {

--- a/src/main/java/com/example/jangboo/account/controller/dto/AccountController.java
+++ b/src/main/java/com/example/jangboo/account/controller/dto/AccountController.java
@@ -23,7 +23,7 @@ public class AccountController {
 	@PostMapping("/register")
 	public ResponseEntity<ResultDto<Void>> registerAccount(
 		@AuthenticationPrincipal CurrentUserInfo userInfo,
-		@RequestParam String fintechUseNum
+		@RequestParam(name="fintech_use_num") String fintechUseNum
 	){
 		accountService.registerAccount(userInfo.userId(),fintechUseNum);
 		return ResponseEntity.ok(ResultDto.of(200,"계좌가 정상적으로 등록되었습니다.",null));

--- a/src/main/java/com/example/jangboo/account/controller/dto/AccountController.java
+++ b/src/main/java/com/example/jangboo/account/controller/dto/AccountController.java
@@ -1,0 +1,31 @@
+package com.example.jangboo.account.controller.dto;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.jangboo.account.service.AccountService;
+import com.example.jangboo.auth.controller.dto.Info.CurrentUserInfo;
+import com.example.jangboo.global.dto.ResultDto;
+
+@RestController
+@RequestMapping("/api/account")
+public class AccountController {
+	private final AccountService accountService;
+
+	public AccountController(AccountService accountService) {
+		this.accountService = accountService;
+	}
+
+	@PostMapping("/register")
+	public ResponseEntity<ResultDto<Void>> registerAccount(
+		@AuthenticationPrincipal CurrentUserInfo userInfo,
+		@RequestParam String fintechUseNum
+	){
+		accountService.registerAccount(userInfo.userId(),fintechUseNum);
+		return ResponseEntity.ok(ResultDto.of(200,"계좌가 정상적으로 등록되었습니다.",null));
+	}
+}

--- a/src/main/java/com/example/jangboo/account/domain/Account.java
+++ b/src/main/java/com/example/jangboo/account/domain/Account.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -19,6 +20,7 @@ public class Account {
 	@Column(name="account_id")
 	private Long id;
 
+	@Getter
 	@Column(name="fintech_use_num")
 	private String fintechUseNum;
 

--- a/src/main/java/com/example/jangboo/account/domain/Account.java
+++ b/src/main/java/com/example/jangboo/account/domain/Account.java
@@ -1,0 +1,33 @@
+package com.example.jangboo.account.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="account")
+public class Account {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name="account_id")
+	private Long id;
+
+	@Column(name="fintech_use_num")
+	private String fintechUseNum;
+
+	@Column(name="owner_id")
+	private Long ownerId;
+
+	@Builder
+	public Account(String fintechUseNum, Long ownerId) {
+		this.fintechUseNum = fintechUseNum;
+		this.ownerId = ownerId;
+	}
+}

--- a/src/main/java/com/example/jangboo/account/domain/AccountRepository.java
+++ b/src/main/java/com/example/jangboo/account/domain/AccountRepository.java
@@ -1,6 +1,9 @@
 package com.example.jangboo.account.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
+	Optional<Account> findByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/example/jangboo/account/domain/AccountRepository.java
+++ b/src/main/java/com/example/jangboo/account/domain/AccountRepository.java
@@ -1,0 +1,6 @@
+package com.example.jangboo.account.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/example/jangboo/account/service/AccountService.java
+++ b/src/main/java/com/example/jangboo/account/service/AccountService.java
@@ -1,5 +1,7 @@
 package com.example.jangboo.account.service;
 
+import java.util.NoSuchElementException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,5 +26,11 @@ public class AccountService {
 				.ownerId(userId)
 				.build()
 		);
+	}
+
+	public String getFintechUseNum(Long userId) {
+		return accountRepository.findByOwnerId(userId)
+			.orElseThrow(()-> new NoSuchElementException("존재하지 않는 계정아이디 입니다."))
+			.getFintechUseNum();
 	}
 }

--- a/src/main/java/com/example/jangboo/account/service/AccountService.java
+++ b/src/main/java/com/example/jangboo/account/service/AccountService.java
@@ -1,0 +1,28 @@
+package com.example.jangboo.account.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.jangboo.account.domain.Account;
+import com.example.jangboo.account.domain.AccountRepository;
+
+@Service
+public class AccountService {
+	@Autowired
+	private final AccountRepository accountRepository;
+
+	public AccountService(AccountRepository accountRepository) {
+		this.accountRepository = accountRepository;
+	}
+
+	@Transactional
+	public void registerAccount(Long userId, String fintechUseNum) {
+		accountRepository.save(
+			Account.builder()
+				.fintechUseNum(fintechUseNum)
+				.ownerId(userId)
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/example/jangboo/auth/controller/AuthController.java
+++ b/src/main/java/com/example/jangboo/auth/controller/AuthController.java
@@ -14,7 +14,7 @@ import com.example.jangboo.global.dto.ResultDto;
 
 @RestController
 @RequestMapping("/api/auth")
-@CrossOrigin(origins = "http://localhost:5500")
+@CrossOrigin(origins = "http://127.0.0.1:5500")
 public class AuthController {
 	private final AuthService authService;
 
@@ -28,6 +28,4 @@ public class AuthController {
 	) throws Exception {
 		return ResponseEntity.ok(ResultDto.of(200,"로그인 성공",authService.getAuthentication(request)));
 	}
-
-
 }

--- a/src/main/java/com/example/jangboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/jangboo/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig{
 			.csrf(csrf -> csrf.disable())// CSRF 보호 비활성화
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.OPTIONS,"/**").permitAll()
-				.requestMatchers("/api/univ/register/**","api/auth/login","/api/oauth/**","/api/role/main","/api/oauth/account-list").permitAll()// 로그인, 회원가입은 모두 허용
+				.requestMatchers("/api/univ/register/**","api/auth/login","/api/oauth/**","/api/role/main","/api/account/**").permitAll()
 				.requestMatchers("/api/univ/signup-link").hasAnyRole("AUDITOR","PRESIDENT")
 				.anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
 			)

--- a/src/main/java/com/example/jangboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/jangboo/global/config/SecurityConfig.java
@@ -27,10 +27,10 @@ public class SecurityConfig{
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 			.cors(cors->cors.disable())
-			.csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
+			.csrf(csrf -> csrf.disable())// CSRF 보호 비활성화
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.OPTIONS,"/**").permitAll()
-				.requestMatchers("/api/univ/register/**","api/auth/login","/api/oauth/**","/api/role/main").permitAll()// 로그인, 회원가입은 모두 허용
+				.requestMatchers("/api/univ/register/**","api/auth/login","/api/oauth/**","/api/role/main","/api/oauth/account-list").permitAll()// 로그인, 회원가입은 모두 허용
 				.requestMatchers("/api/univ/signup-link").hasAnyRole("AUDITOR","PRESIDENT")
 				.anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
 			)

--- a/src/main/java/com/example/jangboo/global/config/WebConfig.java
+++ b/src/main/java/com/example/jangboo/global/config/WebConfig.java
@@ -9,8 +9,8 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**")
-			.allowedOrigins("http://localhost:5500")  // 프론트엔드 주소 허용
+		registry.addMapping("/api/**")
+			.allowedOrigins("http://127.0.0.1:5500")  // 프론트엔드 주소 허용
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")  // Preflight 요청 허용
 			.allowedHeaders("*")  // Authorization 허용
 			.allowCredentials(true);

--- a/src/main/java/com/example/jangboo/global/config/WebConfig.java
+++ b/src/main/java/com/example/jangboo/global/config/WebConfig.java
@@ -12,7 +12,9 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addMapping("/api/**")
 			.allowedOrigins("http://127.0.0.1:5500")  // 프론트엔드 주소 허용
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")  // Preflight 요청 허용
-			.allowedHeaders("*")  // Authorization 허용
-			.allowCredentials(true);
+			.allowedHeaders("Authorization", "Content-Type")
+			.exposedHeaders("Authorization")
+			.allowCredentials(true)
+			.maxAge(3600);
 	}
 }

--- a/src/main/java/com/example/jangboo/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/jangboo/global/filter/JwtAuthenticationFilter.java
@@ -30,9 +30,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-		// 요청에서 Authorization 헤더를 추출하여 JWT 토큰 가져오기
 		final String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-		System.out.println("filter:"+authorizationHeader);
+		System.out.println("jwt filter:"+authorizationHeader);
 		CurrentUserInfo userInfo = null;
 		String jwt = null;
 

--- a/src/main/java/com/example/jangboo/oauth/client/OAuthInterceptor.java
+++ b/src/main/java/com/example/jangboo/oauth/client/OAuthInterceptor.java
@@ -25,7 +25,12 @@ public class OAuthInterceptor implements ClientHttpRequestInterceptor {
 
 	@Override
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
-		TokenInfo token = tokenService.getTokenInfoByUserId(userId);
+		TokenInfo token = null;
+		try {
+			token = tokenService.getTokenInfoByUserId(userId);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 		String accessToken = token.accessToken();
 		String refreshToken = token.refreshToken();
 

--- a/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
+++ b/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
@@ -8,10 +8,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -156,14 +158,24 @@ public class OpenBankingClient {
 	}
 
 	public ResponseEntity<MockTransactionResponse> getMockTransactions(TransactionRequest request) {
-		String accountInfoUrl = "http://localhost:8000/transations";
+		String accountInfoUrl = "http://localhost:8000/transactions";
 
 		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(accountInfoUrl)
-			.queryParam("account_id", request.bankTranId())
+			.queryParam("account_id", request.fintechUseNum())
 			.queryParam("start_date", request.fromDate())
-			.queryParam("end_date", request.toDate());
+			.queryParam("end_date", request.toDate())
+			.queryParam("start_time",request.fromTime())
+			.queryParam("end_time",request.toTime());
 
-		return restTemplate.getForEntity(builder.toUriString(), MockTransactionResponse.class);
+		try {
+			ResponseEntity<MockTransactionResponse> response = restTemplate.getForEntity(builder.toUriString(), MockTransactionResponse.class);
+			return response;
+		} catch (HttpServerErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				throw new RuntimeException("최근 거래내역이 없습니다.");
+			}
+			throw e;
+		}
 	}
 
 	private String DateTimeFormatter(LocalDate date){

--- a/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
+++ b/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
@@ -4,12 +4,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
 import com.example.jangboo.oauth.controller.dto.response.OpenBankingTokenResponse;
 import com.example.jangboo.oauth.token.dto.TokenInfo;
 
@@ -89,5 +93,29 @@ public class OpenBankingClient {
 	public String getAuthUrl(Long userId) {
 		return "https://testapi.openbanking.or.kr/oauth/2.0/authorize?response_type=code&client_id="+
 			clientId+"&redirect_uri="+redirectUri+"&scope="+scope+"&client_info="+userId+"&state=12345678901234567890123456789012&auth_type=0";
+	}
+
+	public ResponseEntity<AccountInfoResponse> getAccountInfo(String userSeqNo, String accessToken) {
+		String accountInfoUrl = "https://testapi.openbanking.or.kr/v2.0/account/list";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + accessToken);  // Access Token 추가
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		String urlTemplate = UriComponentsBuilder.fromHttpUrl(accountInfoUrl)
+			.queryParam("user_seq_no", userSeqNo)
+			.queryParam("include_cancel_yn", "N")
+			.queryParam("sort_order", "A")
+			.encode()
+			.toUriString();
+
+		HttpEntity<?> entity = new HttpEntity<>(headers);
+
+		return restTemplate.exchange(
+			urlTemplate,
+			HttpMethod.GET,
+			entity,
+			AccountInfoResponse.class
+		);
 	}
 }

--- a/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
+++ b/src/main/java/com/example/jangboo/oauth/client/OpenBankingClient.java
@@ -1,5 +1,8 @@
 package com.example.jangboo.oauth.client;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -13,9 +16,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
-import com.example.jangboo.oauth.controller.dto.response.OpenBankingTokenResponse;
+import com.example.jangboo.oauth.client.response.AccountInfoResponse;
+import com.example.jangboo.oauth.client.response.MockTransactionResponse;
+import com.example.jangboo.oauth.client.response.OpenBankingTokenResponse;
+import com.example.jangboo.oauth.client.response.TransactionResponse;
 import com.example.jangboo.oauth.token.dto.TokenInfo;
+import com.example.jangboo.oauth.client.request.TransactionRequest;
 
 @Component
 public class OpenBankingClient {
@@ -117,5 +123,51 @@ public class OpenBankingClient {
 			entity,
 			AccountInfoResponse.class
 		);
+	}
+
+	public ResponseEntity<MockTransactionResponse> getTransactions(String accessToken, TransactionRequest request) {
+		String accountInfoUrl = "https://openapi.openbanking.or.kr/v2.0/account/transaction_list/fin_num";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + accessToken);  // Access Token 추가
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		String urlTemplate = UriComponentsBuilder.fromHttpUrl(accountInfoUrl)
+			.queryParam("bank_tran_id", request.bankTranId())
+			.queryParam("fintech_use_num", request.fintechUseNum())
+			.queryParam("inquiry_type", "A")
+			.queryParam("inquiry_base", "D")
+			.queryParam("from_date", request.fromDate())
+			.queryParam("to_date", request.toDate())
+			.queryParam("tran_dtime", DateTimeFormatter(LocalDate.now()))
+			.encode()
+			.toUriString();
+
+		HttpEntity<?> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<TransactionResponse> response = restTemplate.exchange(
+			urlTemplate,
+			HttpMethod.GET,
+			entity,
+			TransactionResponse.class
+		);
+
+		return getMockTransactions(request);
+	}
+
+	public ResponseEntity<MockTransactionResponse> getMockTransactions(TransactionRequest request) {
+		String accountInfoUrl = "http://localhost:8000/transations";
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(accountInfoUrl)
+			.queryParam("account_id", request.bankTranId())
+			.queryParam("start_date", request.fromDate())
+			.queryParam("end_date", request.toDate());
+
+		return restTemplate.getForEntity(builder.toUriString(), MockTransactionResponse.class);
+	}
+
+	private String DateTimeFormatter(LocalDate date){
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+		return date.format(formatter);
 	}
 }

--- a/src/main/java/com/example/jangboo/oauth/client/request/TransactionRequest.java
+++ b/src/main/java/com/example/jangboo/oauth/client/request/TransactionRequest.java
@@ -1,0 +1,9 @@
+package com.example.jangboo.oauth.client.request;
+
+public record TransactionRequest(
+	String bankTranId,
+	String fintechUseNum,
+	String fromDate,
+	String toDate
+) {
+}

--- a/src/main/java/com/example/jangboo/oauth/client/request/TransactionRequest.java
+++ b/src/main/java/com/example/jangboo/oauth/client/request/TransactionRequest.java
@@ -4,6 +4,8 @@ public record TransactionRequest(
 	String bankTranId,
 	String fintechUseNum,
 	String fromDate,
-	String toDate
+	String toDate,
+	String fromTime,
+	String toTime
 ) {
 }

--- a/src/main/java/com/example/jangboo/oauth/client/response/AccountInfoResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/AccountInfoResponse.java
@@ -1,8 +1,8 @@
-package com.example.jangboo.oauth.controller.dto.response;
+package com.example.jangboo.oauth.client.response;
 
 import java.util.List;
 
-import com.example.jangboo.oauth.controller.dto.Info.AccountInfo;
+import com.example.jangboo.oauth.client.response.info.AccountInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AccountInfoResponse {

--- a/src/main/java/com/example/jangboo/oauth/client/response/MockTransactionResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/MockTransactionResponse.java
@@ -7,9 +7,10 @@ import com.example.jangboo.oauth.client.response.info.MockTransactionInfo;
 public record MockTransactionResponse(
 	String fintechUseNum,
 	String startDate,
-	String toDate,
+	String endDate,
+	String startTime,
+	String endTime,
 	List<MockTransactionInfo> transactions
-
 ) {
 }
 

--- a/src/main/java/com/example/jangboo/oauth/client/response/MockTransactionResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/MockTransactionResponse.java
@@ -1,0 +1,15 @@
+package com.example.jangboo.oauth.client.response;
+
+import java.util.List;
+
+import com.example.jangboo.oauth.client.response.info.MockTransactionInfo;
+
+public record MockTransactionResponse(
+	String fintechUseNum,
+	String startDate,
+	String toDate,
+	List<MockTransactionInfo> transactions
+
+) {
+}
+

--- a/src/main/java/com/example/jangboo/oauth/client/response/OpenBankingTokenResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/OpenBankingTokenResponse.java
@@ -1,4 +1,4 @@
-package com.example.jangboo.oauth.controller.dto.response;
+package com.example.jangboo.oauth.client.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/example/jangboo/oauth/client/response/TransactionResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/TransactionResponse.java
@@ -1,0 +1,59 @@
+package com.example.jangboo.oauth.client.response;
+
+import java.util.List;
+
+import com.example.jangboo.oauth.client.response.info.TransactionInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+public class TransactionResponse {
+	@JsonProperty("api_tran_id")
+	private String apiTranId;
+
+	@JsonProperty("api_tran_dtm")
+	private String apiTranDtm;
+
+	@Getter
+	@JsonProperty("rsp_code")
+	private String rspCode;
+
+	@JsonProperty("rsp_message")
+	private String rspMessage;
+
+	@JsonProperty("bank_tran_id")
+	private String bankTranId;
+
+	@JsonProperty("bank_tran_date")
+	private String bankTranDate;
+
+	@JsonProperty("bank_code_tran")
+	private String bankCodeTran;
+
+	@JsonProperty("bank_rsp_code")
+	private String bankRspCode;
+
+	@JsonProperty("bank_rsp_message")
+	private String bankRspMessage;
+
+	@JsonProperty("bank_name")
+	private String bankName;
+
+	@JsonProperty("fintech_use_num")
+	private String fintechUseNum;
+
+	@JsonProperty("balance_amt")
+	private String balanceAmt;
+
+	@JsonProperty("page_record_cnt")
+	private String pageRecordCnt;
+
+	@JsonProperty("next_page_yn")
+	private String nextPageYn;
+
+	@JsonProperty("befor_inquiry_trace_info")
+	private String beforeInquiryTraceInfo;
+
+	@JsonProperty("res_list")
+	private List<TransactionInfo> resList;
+}

--- a/src/main/java/com/example/jangboo/oauth/client/response/info/AccountInfo.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/info/AccountInfo.java
@@ -1,4 +1,4 @@
-package com.example.jangboo.oauth.controller.dto.Info;
+package com.example.jangboo.oauth.client.response.info;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/example/jangboo/oauth/client/response/info/MockTransactionInfo.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/info/MockTransactionInfo.java
@@ -1,0 +1,12 @@
+package com.example.jangboo.oauth.client.response.info;
+
+public record MockTransactionInfo(
+	String lable,
+	String amount,
+	String transactionType,
+	String balance,
+	String date,
+	String time,
+	String description
+) {
+}

--- a/src/main/java/com/example/jangboo/oauth/client/response/info/TransactionInfo.java
+++ b/src/main/java/com/example/jangboo/oauth/client/response/info/TransactionInfo.java
@@ -1,0 +1,29 @@
+package com.example.jangboo.oauth.client.response.info;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TransactionInfo {
+	@JsonProperty("tran_date")
+	private String tranDate;
+
+	@JsonProperty("tran_time")
+	private String tranTime;
+
+	@JsonProperty("inout_type")
+	private String inoutType;
+
+	@JsonProperty("tran_type")
+	private String tranType;
+
+	@JsonProperty("printed_content")
+	private String printedContent;
+
+	@JsonProperty("tran_amt")
+	private String tranAmt;
+
+	@JsonProperty("after_balance_amt")
+	private String afterBalanceAmt;
+
+	@JsonProperty("branch_name")
+	private String branchName;
+}

--- a/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
+++ b/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
 
 import com.example.jangboo.auth.controller.dto.Info.CurrentUserInfo;
 import com.example.jangboo.global.dto.ResultDto;
@@ -30,13 +31,17 @@ public class OAuthBankController {
 	}
 
 	@GetMapping("/token")
-	public ResponseEntity<ResultDto<Void>> getOpenBankToken(
+	public RedirectView getOpenBankToken(
 		@RequestParam String code,
 		@RequestParam String scope,
 		@RequestParam String state,
 		@RequestParam("client_info") Long userId
 	) throws Exception {
-		return ResponseEntity.ok(ResultDto.of(200,"토큰 발급이 완료되었습니다.", oAuthBankService.getAccessToken(code,userId)));
+		oAuthBankService.getAccessToken(code,userId);
+
+		RedirectView redirectView = new RedirectView();
+		redirectView.setUrl("http://localhost:5500/pages/main/main_manager.html?status=200");
+		return redirectView;
 	}
 
 	@GetMapping("/account-list")
@@ -45,7 +50,7 @@ public class OAuthBankController {
 		return ResponseEntity.ok(ResultDto.of(200,"유저의 계좌정보리스트가 조회되었습니다.",oAuthBankService.getAccountInfo(
 			userInfo.userId())));
 	}
-
+q
 	@GetMapping("/transactions")
 	public ResponseEntity<ResultDto<MockTransactionResponse>> getTransactions(@AuthenticationPrincipal CurrentUserInfo userInfo) throws
 		Exception {

--- a/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
+++ b/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.jangboo.auth.controller.dto.Info.CurrentUserInfo;
 import com.example.jangboo.global.dto.ResultDto;
-import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
+import com.example.jangboo.oauth.client.response.AccountInfoResponse;
+import com.example.jangboo.oauth.client.response.MockTransactionResponse;
 import com.example.jangboo.oauth.service.OAuthBankService;
 
 @RestController
@@ -42,6 +43,13 @@ public class OAuthBankController {
 	public ResponseEntity<ResultDto<AccountInfoResponse>> getAccountList(@AuthenticationPrincipal CurrentUserInfo userInfo) throws
 		Exception {
 		return ResponseEntity.ok(ResultDto.of(200,"유저의 계좌정보리스트가 조회되었습니다.",oAuthBankService.getAccountInfo(
+			userInfo.userId())));
+	}
+
+	@GetMapping("/transactions")
+	public ResponseEntity<ResultDto<MockTransactionResponse>> getTransactions(@AuthenticationPrincipal CurrentUserInfo userInfo) throws
+		Exception {
+		return ResponseEntity.ok(ResultDto.of(200,"유저의 거래내역이 조회되었습니다.",oAuthBankService.getTransactions(
 			userInfo.userId())));
 	}
 }

--- a/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
+++ b/src/main/java/com/example/jangboo/oauth/controller/OAuthBankController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.jangboo.auth.controller.dto.Info.CurrentUserInfo;
 import com.example.jangboo.global.dto.ResultDto;
+import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
 import com.example.jangboo.oauth.service.OAuthBankService;
 
 @RestController
@@ -35,5 +36,12 @@ public class OAuthBankController {
 		@RequestParam("client_info") Long userId
 	) throws Exception {
 		return ResponseEntity.ok(ResultDto.of(200,"토큰 발급이 완료되었습니다.", oAuthBankService.getAccessToken(code,userId)));
+	}
+
+	@GetMapping("/account-list")
+	public ResponseEntity<ResultDto<AccountInfoResponse>> getAccountList(@AuthenticationPrincipal CurrentUserInfo userInfo) throws
+		Exception {
+		return ResponseEntity.ok(ResultDto.of(200,"유저의 계좌정보리스트가 조회되었습니다.",oAuthBankService.getAccountInfo(
+			userInfo.userId())));
 	}
 }

--- a/src/main/java/com/example/jangboo/oauth/controller/dto/Info/AccountInfo.java
+++ b/src/main/java/com/example/jangboo/oauth/controller/dto/Info/AccountInfo.java
@@ -1,0 +1,47 @@
+package com.example.jangboo.oauth.controller.dto.Info;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccountInfo {
+	@JsonProperty("fintech_use_num")
+	private String fintechUseNum;
+
+	@JsonProperty("account_alias")
+	private String accountAlias;
+
+	@JsonProperty("bank_code_std")
+	private String bankCodeStd;
+
+	@JsonProperty("bank_code_sub")
+	private String bankCodeSub;
+
+	@JsonProperty("bank_name")
+	private String bankName;
+
+	@JsonProperty("account_num_masked")
+	private String accountNumMasked;
+
+	@JsonProperty("account_holder_name")
+	private String accountHolderName;
+
+	@JsonProperty("account_holder_type")
+	private String accountHolderType;
+
+	@JsonProperty("account_type")
+	private String accountType;
+
+	@JsonProperty("inquiry_agree_yn")
+	private String inquiryAgreeYn;
+
+	@JsonProperty("inquiry_agree_dtime")
+	private String inquiryAgreeDtime;
+
+	@JsonProperty("transfer_agree_yn")
+	private String transferAgreeYn;
+
+	@JsonProperty("transfer_agree_dtime")
+	private String transferAgreeDtime;
+
+	@JsonProperty("account_state")
+	private String accountState;
+}

--- a/src/main/java/com/example/jangboo/oauth/controller/dto/response/AccountInfoResponse.java
+++ b/src/main/java/com/example/jangboo/oauth/controller/dto/response/AccountInfoResponse.java
@@ -1,0 +1,29 @@
+package com.example.jangboo.oauth.controller.dto.response;
+
+import java.util.List;
+
+import com.example.jangboo.oauth.controller.dto.Info.AccountInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccountInfoResponse {
+	@JsonProperty("api_tran_id")
+	private String apiTranId;
+
+	@JsonProperty("api_tran_dtm")
+	private String apiTranDtm;
+
+	@JsonProperty("rsp_code")
+	private String rspCode;
+
+	@JsonProperty("rsp_message")
+	private String rspMessage;
+
+	@JsonProperty("user_name")
+	private String userName;
+
+	@JsonProperty("res_cnt")
+	private String resCnt;
+
+	@JsonProperty("res_list")
+	private List<AccountInfo> resList;
+}

--- a/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
+++ b/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
@@ -1,20 +1,33 @@
 package com.example.jangboo.oauth.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Component;
 
+import com.example.jangboo.account.service.AccountService;
 import com.example.jangboo.oauth.client.OpenBankingClient;
-import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
+import com.example.jangboo.oauth.client.request.TransactionRequest;
+import com.example.jangboo.oauth.client.response.AccountInfoResponse;
+import com.example.jangboo.oauth.client.response.MockTransactionResponse;
 import com.example.jangboo.oauth.token.dto.TokenInfo;
 import com.example.jangboo.oauth.token.service.TokenService;
+import com.example.jangboo.transaction.service.TransactionService;
 
 @Component
 public class OAuthBankService {
 	private final OpenBankingClient client;
 	private final TokenService tokenService;
+	private final AccountService accountService;
+	private final TransactionService transactionService;
 
-	public OAuthBankService(OpenBankingClient client, TokenService tokenService) {
+	public OAuthBankService(OpenBankingClient client, TokenService tokenService, AccountService accountService,
+		TransactionService transactionService) {
 		this.client = client;
 		this.tokenService = tokenService;
+		this.accountService = accountService;
+		this.transactionService = transactionService;
 	}
 
 	public String getAuthUrl(Long userId){
@@ -29,4 +42,26 @@ public class OAuthBankService {
 		TokenInfo tokenInfo = tokenService.getTokenInfoByUserId(userId);
 		return client.getAccountInfo(tokenInfo.userSeqNo(),tokenInfo.accessToken()).getBody();
 	}
+
+	public MockTransactionResponse getTransactions(Long userId) throws Exception {
+		TokenInfo tokenInfo = tokenService.getTokenInfoByUserId(userId);
+		TransactionRequest request = getTransactionRequestInfo(userId);
+
+		return client.getTransactions(tokenInfo.accessToken(), request).getBody();
+	}
+
+	private TransactionRequest getTransactionRequestInfo(Long userId) {
+		return new TransactionRequest(
+			"1234",
+			accountService.getFintechUseNum(userId),
+			LocalDateToString(transactionService.findLatestUpdatedTransactionDate(userId)),
+			LocalDateToString(LocalDate.now())
+		);
+	}
+
+	private String LocalDateToString(LocalDate date) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+		return date.format(formatter);
+	}
+
 }

--- a/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
+++ b/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
@@ -1,9 +1,11 @@
 package com.example.jangboo.oauth.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Component;
 
 import com.example.jangboo.account.service.AccountService;
@@ -47,21 +49,31 @@ public class OAuthBankService {
 		TokenInfo tokenInfo = tokenService.getTokenInfoByUserId(userId);
 		TransactionRequest request = getTransactionRequestInfo(userId);
 
-		return client.getTransactions(tokenInfo.accessToken(), request).getBody();
+		return transactionService.saveTransactions(Optional.ofNullable(
+			client.getTransactions(tokenInfo.accessToken(), request).getBody()
+		).orElseThrow(() -> new IllegalStateException("거래 내역을 가져오지 못했습니다.")),userId);
 	}
 
 	private TransactionRequest getTransactionRequestInfo(Long userId) {
+		LocalDateTime latestDateTime = transactionService.findLatestUpdatedTransactionDateTime(userId);
 		return new TransactionRequest(
 			"1234",
 			accountService.getFintechUseNum(userId),
-			LocalDateToString(transactionService.findLatestUpdatedTransactionDate(userId)),
-			LocalDateToString(LocalDate.now())
+			LocalDateToString(latestDateTime.toLocalDate()),
+			LocalDateToString(LocalDate.now()),
+			LocalTimeToString(latestDateTime.toLocalTime().plusSeconds(1)),
+			LocalTimeToString(LocalDateTime.now().toLocalTime())
 		);
 	}
 
 	private String LocalDateToString(LocalDate date) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 		return date.format(formatter);
+	}
+
+	private String LocalTimeToString(LocalTime time) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+		return time.format(formatter);
 	}
 
 }

--- a/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
+++ b/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
@@ -60,7 +60,7 @@ public class OAuthBankService {
 	}
 
 	private String LocalDateToString(LocalDate date) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 		return date.format(formatter);
 	}
 

--- a/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
+++ b/src/main/java/com/example/jangboo/oauth/service/OAuthBankService.java
@@ -3,6 +3,8 @@ package com.example.jangboo.oauth.service;
 import org.springframework.stereotype.Component;
 
 import com.example.jangboo.oauth.client.OpenBankingClient;
+import com.example.jangboo.oauth.controller.dto.response.AccountInfoResponse;
+import com.example.jangboo.oauth.token.dto.TokenInfo;
 import com.example.jangboo.oauth.token.service.TokenService;
 
 @Component
@@ -21,5 +23,10 @@ public class OAuthBankService {
 
 	public Void getAccessToken(String code,Long userId) throws Exception {
 		return tokenService.createTokenInfo(client.requestAccessToken(code),userId);
+	}
+
+	public AccountInfoResponse getAccountInfo(Long userId) throws Exception {
+		TokenInfo tokenInfo = tokenService.getTokenInfoByUserId(userId);
+		return client.getAccountInfo(tokenInfo.userSeqNo(),tokenInfo.accessToken()).getBody();
 	}
 }

--- a/src/main/java/com/example/jangboo/oauth/token/domain/Token.java
+++ b/src/main/java/com/example/jangboo/oauth/token/domain/Token.java
@@ -1,49 +1,39 @@
 package com.example.jangboo.oauth.token.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
+import java.io.Serializable;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "open_banking_token")
-public class Token {
+@Getter
+@NoArgsConstructor
+@RedisHash(value = "open_banking_token", timeToLive = 3600)
+public class Token implements Serializable {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "token_id")
 	private Long id;
 
-	@Getter
-	@Column(name = "access_token",length = 512)
 	private String accessToken;
-
-	@Getter
-	@Column(name = "refresh_token",length = 512)
 	private String refreshToken;
-
-	@Getter
-	@Column(name = "user_seq_no")
 	private String userSeqNo;
 
-	@Column(name ="owner_id")
+	@Indexed
 	private Long ownerId;
 
 	@Builder
-	public Token(String accessToken, String refreshToken, String userSeqNo, Long ownerId) {
+	public Token(Long id, String accessToken, String refreshToken, String userSeqNo, Long ownerId) {
+		this.id = id;
 		this.accessToken = accessToken;
 		this.refreshToken = refreshToken;
 		this.userSeqNo = userSeqNo;
 		this.ownerId = ownerId;
 	}
 
-	public void refresh(String accessToken,String refreshToken){
+	public void refresh(String accessToken, String refreshToken) {
 		this.accessToken = accessToken;
 		this.refreshToken = refreshToken;
 	}

--- a/src/main/java/com/example/jangboo/oauth/token/domain/TokenRepository.java
+++ b/src/main/java/com/example/jangboo/oauth/token/domain/TokenRepository.java
@@ -1,7 +1,9 @@
 package com.example.jangboo.oauth.token.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
-public interface TokenRepository extends JpaRepository<Token, Long> {
+@Repository
+public interface TokenRepository extends CrudRepository<Token, Long> {
 	Token findByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/example/jangboo/oauth/token/service/TokenService.java
+++ b/src/main/java/com/example/jangboo/oauth/token/service/TokenService.java
@@ -21,6 +21,7 @@ public class TokenService {
 
 	@Transactional
 	public Void createTokenInfo(TokenInfo tokenInfo,Long userId) throws Exception {
+		System.out.println(tokenInfo.userSeqNo()+" "+tokenInfo.accessToken());
 		tokenRepository.save(
 			Token.builder()
 				.accessToken(getEncryptedToken(tokenInfo.accessToken()))
@@ -40,14 +41,15 @@ public class TokenService {
 		return tokenEncryptor.decrypt(token);
 	}
 
-	public TokenInfo getTokenInfoByUserId(Long userId) {
+	public TokenInfo getTokenInfoByUserId(Long userId) throws Exception {
 		Token token = tokenRepository.findByOwnerId(userId);
-		return new TokenInfo(token.getAccessToken(),token.getRefreshToken(),token.getUserSeqNo());
+		return new TokenInfo(getDecryptedToken(token.getAccessToken()),getDecryptedToken(token.getRefreshToken()),token.getUserSeqNo());
 	}
 
 	@Transactional
 	public void refreshTokens(Long userId, TokenInfo tokenInfo) {
 		Token token = tokenRepository.findByOwnerId(userId);
+
 		token.refresh(tokenInfo.accessToken(),tokenInfo.refreshToken());
 	}
 }

--- a/src/main/java/com/example/jangboo/transaction/controller/TransactionController.java
+++ b/src/main/java/com/example/jangboo/transaction/controller/TransactionController.java
@@ -1,0 +1,7 @@
+package com.example.jangboo.transaction.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TransactionController {
+}

--- a/src/main/java/com/example/jangboo/transaction/domain/Transaction.java
+++ b/src/main/java/com/example/jangboo/transaction/domain/Transaction.java
@@ -45,6 +45,7 @@ public class Transaction {
 	@Column(name="date")
 	private LocalDate date;
 
+	@Getter
 	@Column(name="time")
 	private LocalTime time;
 

--- a/src/main/java/com/example/jangboo/transaction/domain/Transaction.java
+++ b/src/main/java/com/example/jangboo/transaction/domain/Transaction.java
@@ -1,0 +1,65 @@
+package com.example.jangboo.transaction.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "transaction",indexes = {
+	@Index(name = "idx_transaction_date", columnList = "date")}
+)
+public class Transaction {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "transaction_id")
+	private Long id;
+
+	@Column(name="account_owner_id")
+	private Long accountOwnerId;
+
+	@Column(name="lable")
+	private String lable;
+
+	@Column(name="amount")
+	private String amount;
+
+	@Column(name="transactionType")
+	private String transactionType;
+
+	@Column(name="balance")
+	private String balance;
+
+	@Getter
+	@Column(name="date")
+	private LocalDate date;
+
+	@Column(name="time")
+	private LocalTime time;
+
+	@Column(name="description")
+	private String description;
+
+	@Builder
+	public Transaction(Long accountOwnerId, String lable, String amount, String transactionType, String balance, LocalDate date, LocalTime time, String description) {
+		this.accountOwnerId = accountOwnerId;
+		this.lable = lable;
+		this.amount = amount;
+		this.transactionType = transactionType;
+		this.balance = balance;
+		this.date = date;
+		this.time = time;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/example/jangboo/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/example/jangboo/transaction/domain/TransactionRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
-	Optional<Transaction> findTopByAccountOwnerIdOrderByDateDesc(Long accountOwnerId);
+	Optional<Transaction> findTopByAccountOwnerIdOrderByDateDescTimeDesc(Long accountOwnerId);
 }

--- a/src/main/java/com/example/jangboo/transaction/domain/TransactionRepository.java
+++ b/src/main/java/com/example/jangboo/transaction/domain/TransactionRepository.java
@@ -1,0 +1,9 @@
+package com.example.jangboo.transaction.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+	Optional<Transaction> findTopByAccountOwnerIdOrderByDateDesc(Long accountOwnerId);
+}

--- a/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
+++ b/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
@@ -1,9 +1,17 @@
 package com.example.jangboo.transaction.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.jangboo.oauth.client.response.MockTransactionResponse;
 import com.example.jangboo.transaction.domain.Transaction;
 import com.example.jangboo.transaction.domain.TransactionRepository;
 
@@ -23,5 +31,41 @@ public class TransactionService {
 
 	private LocalDate getFistDayOfYear() {
 		return LocalDate.of(LocalDate.now().getYear(), 1, 1);
+	}
+
+	@Transactional
+	public MockTransactionResponse saveTransactions (MockTransactionResponse transaction,Long userId){
+		// Transaction 엔티티 리스트 생성 및 저장
+		List<Transaction> transactions = transaction.transactions().stream()
+			.map(t -> Transaction.builder()
+				.transactionType(t.transactionType())
+				.amount(t.amount())
+				.date((LocalDate)parseDateTime(t.date(),"yyyy-MM-dd"))
+				.time((LocalTime)parseDateTime(t.time(),"HH:mm:ss"))
+				.description(t.description())
+				.accountOwnerId(userId)
+				.build()
+			)
+			.collect(Collectors.toList());
+
+		// 저장된 모든 거래내역을 repository에 저장
+		transactionRepository.saveAll(transactions);
+
+		// 필요한 응답 객체 반환
+		return transaction;
+	}
+
+	public Object parseDateTime(String input, String pattern) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+
+		if (pattern.equals("yyyy-MM-dd")) {
+			return LocalDate.parse(input, formatter);
+		} else if (pattern.equals("HH:mm:ss")) {
+			return LocalTime.parse(input, formatter);
+		} else if (pattern.equals("yyyy-MM-dd HH:mm:ss")) {
+			return LocalDateTime.parse(input, formatter);
+		} else {
+			throw new IllegalArgumentException("지원하지 않는 포맷입니다.");
+		}
 	}
 }

--- a/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
+++ b/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
@@ -1,0 +1,27 @@
+package com.example.jangboo.transaction.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+
+import com.example.jangboo.transaction.domain.Transaction;
+import com.example.jangboo.transaction.domain.TransactionRepository;
+
+@Service
+public class TransactionService {
+	private final TransactionRepository transactionRepository;
+
+	public TransactionService(TransactionRepository transactionRepository) {
+		this.transactionRepository = transactionRepository;
+	}
+
+	public LocalDate findLatestUpdatedTransactionDate(Long userId) {
+		return transactionRepository.findTopByAccountOwnerIdOrderByDateDesc(userId)
+			.map(Transaction::getDate)
+			.orElseGet(this::getFistDayOfYear);
+	}
+
+	private LocalDate getFistDayOfYear() {
+		return LocalDate.of(LocalDate.now().getYear(), 1, 1);
+	}
+}

--- a/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
+++ b/src/main/java/com/example/jangboo/transaction/service/TransactionService.java
@@ -23,19 +23,19 @@ public class TransactionService {
 		this.transactionRepository = transactionRepository;
 	}
 
-	public LocalDate findLatestUpdatedTransactionDate(Long userId) {
-		return transactionRepository.findTopByAccountOwnerIdOrderByDateDesc(userId)
-			.map(Transaction::getDate)
-			.orElseGet(this::getFistDayOfYear);
+	public LocalDateTime findLatestUpdatedTransactionDateTime(Long userId) {
+		return transactionRepository
+			.findTopByAccountOwnerIdOrderByDateDescTimeDesc(userId)
+			.map(transaction -> LocalDateTime.of(transaction.getDate(), transaction.getTime()))
+			.orElseGet(this::getFirstDayOfYear);
 	}
 
-	private LocalDate getFistDayOfYear() {
-		return LocalDate.of(LocalDate.now().getYear(), 1, 1);
+	private LocalDateTime getFirstDayOfYear() {
+		return LocalDateTime.of(LocalDate.now().withDayOfYear(1), LocalTime.MIDNIGHT); // 1월 1일 00:00:00
 	}
 
 	@Transactional
 	public MockTransactionResponse saveTransactions (MockTransactionResponse transaction,Long userId){
-		// Transaction 엔티티 리스트 생성 및 저장
 		List<Transaction> transactions = transaction.transactions().stream()
 			.map(t -> Transaction.builder()
 				.transactionType(t.transactionType())
@@ -48,10 +48,8 @@ public class TransactionService {
 			)
 			.collect(Collectors.toList());
 
-		// 저장된 모든 거래내역을 repository에 저장
 		transactionRepository.saveAll(transactions);
 
-		// 필요한 응답 객체 반환
 		return transaction;
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,7 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 10MB
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## 설명
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- #18 
### ✅ 계좌 도메인 추가
- **계좌 목록 조회 api**
  - 금결원에 등록된 계좌중 학생회비 계좌를 등록할 수 있도록 목록을 조회할 수 있습니다.
 
- 계좌 등록 api
  - 학생회비 계좌를 owner_id와 함께 저장합니다.

### ✅ 거래내역 도메인 추가
- 거래내역 업데이트 api 
  - 은행 서버에서 거래내역 최신화를 하는 로직입니다.
  - 불러온 transaction의 응답 중 필요한 정보만 저장합니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 참고사항
- 프론트 연동중 CORS 관련 오류가 떠서 추가한 코드가 있습니다.
