### PR TITLE
Feat/#34 공통 예외처리

### DIFF
--- a/src/main/java/com/example/jangboo/global/dto/ResultDto.java
+++ b/src/main/java/com/example/jangboo/global/dto/ResultDto.java
@@ -1,6 +1,6 @@
 package com.example.jangboo.global.dto;
 
-import com.example.jangboo.global.enums.ErrorCode;
+import com.example.jangboo.global.enums.BaseErrorCode;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,7 @@ public class ResultDto<D>{
 
 
 	// 실패 응답을 생성하는 메서드
-	public static ResultDto<String> fail(ErrorCode err) {
+	public static ResultDto<String> fail(BaseErrorCode err) {
 		return new ResultDto<>(err.getHttpStatus().value(), err.getMessage(), err.getErrorCode());
 	}
 }

--- a/src/main/java/com/example/jangboo/global/dto/ResultDto.java
+++ b/src/main/java/com/example/jangboo/global/dto/ResultDto.java
@@ -1,5 +1,6 @@
 package com.example.jangboo.global.dto;
 
+import com.example.jangboo.global.enums.ErrorCode;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +10,11 @@ public class ResultDto<D>{
 	private final Integer code;
 	private final String message;
 	private final D data;
+
+
+
+	// 실패 응답을 생성하는 메서드
+	public static ResultDto<String> fail(ErrorCode err) {
+		return new ResultDto<>(err.getHttpStatus().value(), err.getMessage(), err.getErrorCode());
+	}
 }

--- a/src/main/java/com/example/jangboo/global/enums/BaseErrorCode.java
+++ b/src/main/java/com/example/jangboo/global/enums/BaseErrorCode.java
@@ -1,7 +1,9 @@
 package com.example.jangboo.global.enums;
 
+import org.springframework.http.HttpStatus;
+
 public interface BaseErrorCode {
-    Integer getHttpStatus();
+    HttpStatus getHttpStatus();
     String getMessage();
     String getErrorCode();
 }

--- a/src/main/java/com/example/jangboo/global/enums/BaseErrorCode.java
+++ b/src/main/java/com/example/jangboo/global/enums/BaseErrorCode.java
@@ -1,0 +1,7 @@
+package com.example.jangboo.global.enums;
+
+public interface BaseErrorCode {
+    Integer getHttpStatus();
+    String getMessage();
+    String getErrorCode();
+}

--- a/src/main/java/com/example/jangboo/global/enums/ErrorCode.java
+++ b/src/main/java/com/example/jangboo/global/enums/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.jangboo.global.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode implements BaseErrorCode{
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다.", "ERROR-BR-000"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다.", "ERROR-UA-000"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 요청 정보를 찾을 수 없습니다.", "ERROR-NF-000"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "금지된 요청입니다.", "ERROR-FB-000"),
+    CONFLICT(HttpStatus.CONFLICT, "해당 요청에 대해 충돌이 일어났습니다.", "ERROR-CF-000"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다. 관리자에게 문의하세요", "ERROR-ISE-000");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String errorCode;
+}

--- a/src/main/java/com/example/jangboo/global/error/CustomException.java
+++ b/src/main/java/com/example/jangboo/global/error/CustomException.java
@@ -1,0 +1,14 @@
+package com.example.jangboo.global.error;
+
+import com.example.jangboo.global.enums.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    final BaseErrorCode errorCode;
+
+    public CustomException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/jangboo/global/error/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jangboo/global/error/CustomExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.example.jangboo.global.error;
+
+import com.example.jangboo.global.dto.ResultDto;
+import com.example.jangboo.global.enums.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ResultDto<String>> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getErrorCode().getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ResultDto.fail(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ResultDto<String>> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResultDto.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}


### PR DESCRIPTION
## 설명
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
응답 Dto에 실패시 생성자 추가
공통 에러에대한 예외처리 코드 추가

<!---- Resolves: #(Isuue Number) -->
#34 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 참고사항
- 해당 도메인에맞는 error code를 직접 만들고 싶다면 아래와 같이 BaseErrorCode의 구현체를 만들어주시면 됩니다. 그리고 해당 코드를 이용해서 CustomException을 터뜨리면 클라이언트에게 해당 정보가 전달됩니다.
<img width="1006" alt="스크린샷 2024-11-09 오후 12 12 37" src="https://github.com/user-attachments/assets/78085aa8-5a36-43bd-b4be-bc8ad2c36416">

- 현재 아래와 같이 예외처리한것들은 다 '내부서버 오류'로 클라이언트에 반환됩니다. CustomException으로 처리하거나 해당 예외(예:NoSuchElementException)를 CustomExceptionHandler에 등록한 후 클라이언트에게 어떤 응답을 줄것인지 직접 정의하세요.
<img width="720" alt="스크린샷 2024-11-09 오후 12 18 14" src="https://github.com/user-attachments/assets/01e1dd4d-b670-44c9-9985-f15e446223ef">

- 아래는 위 코드의 사용 예시입니다.
<img width="650" alt="스크린샷 2024-11-09 오후 12 28 24" src="https://github.com/user-attachments/assets/1984af8e-f47d-455c-b822-d55af5cd15f5">

### CustomExceptionHandler에 특정 예외를 등록하는법(참고)
아래 예시는 우리프로젝트의 코드가 아님 참고용
<img width="928" alt="스크린샷 2024-11-09 오후 12 31 31" src="https://github.com/user-attachments/assets/847fed41-dd03-4a28-a003-ea6108ea7081">


